### PR TITLE
Remove compilation results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 tsconfig.tsbuildinfo
+ui/lib
+

--- a/ui/lib/index.js
+++ b/ui/lib/index.js
@@ -1,7 +1,0 @@
-import { jsx as _jsx } from "react/jsx-runtime";
-import FullCalendar from "@fullcalendar/react";
-function Index(_a) {
-    var x = {};
-    return (_jsx("div", { children: _jsx(FullCalendar, {}, void 0) }, void 0));
-}
-export default Index;


### PR DESCRIPTION
The README instructions did not work on a fresh clone,
because folder `ui/lib` already contains results of a successful build.
Fixed by removing `ui/lib` and adding it to `.gitignore`.